### PR TITLE
Delete mutations

### DIFF
--- a/server/migrations/20190222141347_delete_characters_draftId.js
+++ b/server/migrations/20190222141347_delete_characters_draftId.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex, Promise) {
+    return knex.schema.table('characters', function(t) {
+        t.dropColumn('drafterId');
+    });
+};
+
+exports.down = function(knex, Promise) {
+    return knex.schema.table('characters', function(t) {
+        t.bigInteger('drafterId').unsigned().index().references('id').inTable('drafters').onDelete('CASCADE');
+    });
+};

--- a/server/migrations/20190222161445_add_characters_drafterId.js
+++ b/server/migrations/20190222161445_add_characters_drafterId.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex, Promise) {
+    return knex.schema.table('characters', function(t) {
+        t.bigInteger('drafterId').unsigned().index().references('id').inTable('drafters').onDelete('SET NULL')
+    });
+};
+
+exports.down = function(knex, Promise) {
+    return knex.schema.table('characters', function(t) {
+        t.dropColumn('drafterId');
+    });
+};

--- a/server/schema/character.js
+++ b/server/schema/character.js
@@ -6,6 +6,7 @@ const typeDef = `
         addCharacter(showId: ID!, name: String!, image: String = "${defaultImage}"): Character
         addCharacterDrafter(characterId: ID!, drafterId: ID!): Character
         editCharacter(characterId: ID!, name: String!, image: String!, drafterId: ID!): Character
+        deleteCharacter(id: ID!): Character
     }
 
     type Character {
@@ -41,6 +42,13 @@ const resolvers = {
                 .then(data => {
                     return data
                 })
+        },
+        deleteCharacter: (parent, args) => {
+            const deleteCharacterQuery = `DELETE FROM characters WHERE "id" = ${args.id} RETURNING *`;
+            return db.one(deleteCharacterQuery)
+                .then(data => {
+                    return data
+                })            
         }
     },
     Character: {

--- a/server/schema/drafter.js
+++ b/server/schema/drafter.js
@@ -9,6 +9,7 @@ const typeDef = `
     extend type Mutation {
         addDrafter(name: String!, image: String = "${defaultImage}", color: String!): Drafter
         editDrafter(id: ID!, name: String!, image: String!, color: String!): Drafter
+        deleteDrafter(id: ID!): Drafter
     }
 
     type Drafter {
@@ -42,6 +43,13 @@ const resolvers = {
         editDrafter: (parent, args) => {
             const editDrafterQuery = `UPDATE drafters SET "name" = '${args.name}', "image" = '${args.image}', "color" = '${args.color}' WHERE "id" = ${args.id} RETURNING *`;
             return db.one(editDrafterQuery)
+                .then(data => {
+                    return data
+                })
+        },
+        deleteDrafter: (parent, args) => {
+            const deleteDrafterQuery = `DELETE FROM drafters WHERE "id" = ${args.id} RETURNING *`;
+            return db.one(deleteDrafterQuery)
                 .then(data => {
                     return data
                 })

--- a/server/schema/episodeScore.js
+++ b/server/schema/episodeScore.js
@@ -4,6 +4,7 @@ const typeDef = `
     extend type Mutation {
         addEpisodeScore(showId: ID!, characterId: ID!, number: Int!, points: Int!): EpisodeScore
         editEpisodeScore(id: ID!, points: Int!): EpisodeScore
+        deleteEpisodeScore(id: ID!): EpisodeScore 
     }
 
     type EpisodeScore {
@@ -28,7 +29,14 @@ const resolvers = {
                 .then(data => {
                     return data 
                 })   
-        }
+        },
+        deleteEpisodeScore: (parent, args) => {
+            const deleteEpisodeScoreQuery = `DELETE FROM episode_scores WHERE "id" = ${args.id} RETURNING *`;
+            return db.one(deleteEpisodeScoreQuery)
+                .then(data => {
+                    return data
+                })
+        }       
     }
 };
 

--- a/server/schema/rule.js
+++ b/server/schema/rule.js
@@ -4,6 +4,7 @@ const typeDef = `
     extend type Mutation {
         addRule(showId: ID!, name: String!, points: Int!): Rule
         editRule(id: ID!, name: String!, points: Int!): Rule
+        deleteRule(id: ID!): Rule 
     }
 
     type Rule {
@@ -27,6 +28,13 @@ const resolvers = {
             return db.one(editRuleQuery)
                 .then(data => {
                     return data 
+                })
+        },
+        deleteRule: (parent, args) => {
+            const deleteRuleQuery = `DELETE FROM rules WHERE "id" = ${args.id} RETURNING *`;
+            return db.one(deleteRuleQuery)
+                .then(data => {
+                    return data
                 })
         }
     }

--- a/server/schema/show.js
+++ b/server/schema/show.js
@@ -8,6 +8,7 @@ const typeDef = `
     extend type Mutation {
         addShow(name: String!): Show
         editShowName(id: ID!, name: String!): Show
+        deleteShow(id: ID!): Show
     }
 
     type Show {
@@ -42,6 +43,13 @@ const resolvers = {
                 .then(data => {
                     return data
                 })           
+        },
+        deleteShow: (parent, args) => {
+            const deleteShowQuery = `DELETE FROM shows WHERE "id" = ${args.id} RETURNING *`;
+            return db.one(deleteShowQuery)
+                .then(data => {
+                    return data
+                })    
         }
     },
     Show: {


### PR DESCRIPTION
also had to create new migrations to change onDelete of the drafterId column in the characters table from 'CASCADE' to 'SET NULL'. That way, when a drafter is deleted, its characters are not also deleted. Instead the drafterId column of such previously owned characters will be Null.